### PR TITLE
🐈 Typo fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ WASC | v2.0.0 | [link](http://projects.webappsec.org/Threat%20Classification%20T
 
 ## Tool Usage
 
-Download form official website using the links in Data Source section above. Unzip as needed.
+Download from official website using the links in Data Source section above. Unzip as needed.
 Execute the tool with proper parameters, samples below.
 
 Generate CWE Sarif file

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo stores SARIF Taxonomies
 
 ## Data Source
 
-| **Taxonomy** | **Version** | **Souce File** | **SARIF File** |
+| **Taxonomy** | **Version** | **Source File** | **SARIF File** |
 -----|-----|-----|-----
 CWE | v4.3 | [link](https://cwe.mitre.org/data/xml/cwec_v4.3.xml.zip) | [CWE_v4.3.sarif](CWE_v4.3.sarif)
 CWE | v4.4 | [link](https://cwe.mitre.org/data/xml/cwec_v4.4.xml.zip) | [CWE_v4.4.sarif](CWE_v4.4.sarif)


### PR DESCRIPTION
🌊 This PR fixes a few typos in `README.md`:

- **Data Source** instead of **Data Souce**
- **download from official website** instead of **download form official website**